### PR TITLE
fix(search): correct date range upper bound

### DIFF
--- a/internal/search/term_date.go
+++ b/internal/search/term_date.go
@@ -112,7 +112,7 @@ func dateRangeQuery(field string, r Range) (any, error) {
 	}
 
 	if r.max != "" {
-		dateStr, err := convertDate(r.min)
+		dateStr, err := convertDate(r.max)
 		if err != nil {
 			return nil, fmt.Errorf("cannot build a date range query with an invalid date %s: %w", r.max, err)
 		}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,10 @@
 package main
 
-import "github.com/gencon_buddy_api/cmd"
+import (
+	_ "time/tzdata"
+
+	"github.com/gencon_buddy_api/cmd"
+)
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
## Summary

- Fixes `dateRangeQuery` in `internal/search/term_date.go` passing `r.min` instead of `r.max` when building the upper bound, which caused all date range queries to silently use the lower bound for both ends of the range
- Adds `_ "time/tzdata"` import to `main.go` to embed the IANA timezone database in the binary, required for `convertDate` to work in minimal container environments (e.g. `scratch`-based Docker images)

Closes #12

## Test plan

- [ ] Send a date range search: `GET /api/events/search?startDateTime=[2024-08-02T05:00:00-04:00,2024-08-04T05:00:00-04:00]`
- [ ] Confirm the result count is greater than a collapsed same-bound query: `[2024-08-02T05:00:00-04:00,2024-08-02T05:00:00-04:00]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)