### PR TITLE
fix(enum): fix external -> internal enum handling

### DIFF
--- a/internal/event/enums.go
+++ b/internal/event/enums.go
@@ -85,6 +85,8 @@ func ValidateType(v string) error {
 	}
 }
 
+// EventTypeFromSearchTerm converts an external facing enum value to the constant
+// enum value for the event stored in the data store.
 func EventTypeFromSearchTerm(s string) Type {
 	switch s {
 	case "SEM":
@@ -149,6 +151,8 @@ func ValidateEXP(v string) error {
 	}
 }
 
+// EXPFromSearchTerm converts an external facing enum value to the constant
+// enum value for the event stored in the data store.
 func EXPFromSearchTerm(s string) EXP {
 	switch s {
 	case "none":
@@ -183,6 +187,8 @@ func ValidateRegistration(v string) error {
 	}
 }
 
+// RegistrationFromSearchTerm converts an external facing enum value to the constant
+// enum value for the event stored in the data store.
 func RegistrationFromSearchTerm(s string) Registration {
 	switch s {
 	case "open":
@@ -220,6 +226,8 @@ func ValidateCategory(v string) error {
 	}
 }
 
+// CategoryFromSearchTerm converts an external facing enum value to the constant
+// enum value for the event stored in the data store.
 func CategoryFromSearchTerm(s string) Category {
 	switch s {
 	case "none":

--- a/internal/event/search.go
+++ b/internal/event/search.go
@@ -27,17 +27,30 @@ func NewSearchField(f string, value string) (search.Term, error) {
 	}
 
 	switch field {
-	case GameID, EventType, AgeRequired, ExperienceRequired,
-		AttendeeRegistration, SpecialCategory, MaterialsRequired:
+	// keywords that are specific enum types
+	case AgeRequired:
+		return search.NewKeywordSingle(f, string(AgeGroupFromSearchTerm(value)))
+	case EventType:
+		return search.NewKeywordSingle(f, string(EventTypeFromSearchTerm(value)))
+	case ExperienceRequired:
+		return search.NewKeywordSingle(f, string(EXPFromSearchTerm(value)))
+	case AttendeeRegistration:
+		return search.NewKeywordSingle(f, string(RegistrationFromSearchTerm(value)))
+	case SpecialCategory:
+		return search.NewKeywordSingle(f, string(CategoryFromSearchTerm(value)))
+	// Keywords that have no special consideration
+	case GameID, MaterialsRequired:
 		return search.NewKeyword(f, value)
 	// integer
 	case Year, MinPlayers, MaxPlayers, RoundNumber,
 		TotalRounds, TicketsAvailable:
 		return search.NewNumber(f, value)
+	// Generic full text search fields
 	case Group, Title, ShortDescription, LongDescription, GameSystem,
 		RulesEdition, MaterialsProvided, MaterialsRequiredDetails, GMNames, Tournament,
 		Location, RoomName, TableNumber, Prize, RulesComplexity:
 		return search.NewText(f, value)
+	// Full text search fields that have a subfield as well
 	case Email, Website:
 		text, err := search.NewText(f, value)
 		if err != nil {
@@ -54,8 +67,10 @@ func NewSearchField(f string, value string) (search.Term, error) {
 	// double
 	case Duration, MinimumPlayTime, Cost:
 		return search.NewNumber(f, value)
+	// Date searches
 	case StartDateTime, EndDateTime, LastModified, AlsoRuns:
 		return search.NewDate(f, value)
+	// Special filter
 	case Filter:
 		return FilterTerm{value: value}, nil
 	default:
@@ -139,45 +154,45 @@ const (
 
 var (
 	allFields = map[Field]any{
-		Filter:               struct{}{},
-		GameID:               struct{}{},
-		Year:                 struct{}{},
-		Group:                struct{}{},
-		Title:                struct{}{},
-		ShortDescription:     struct{}{},
-		LongDescription:      struct{}{},
-		EventType:            struct{}{},
-		GameSystem:           struct{}{},
-		RulesEdition:         struct{}{},
-		MinPlayers:           struct{}{},
-		MaxPlayers:           struct{}{},
-		AgeRequired:          struct{}{},
-		ExperienceRequired:   struct{}{},
+		Filter:                   struct{}{},
+		GameID:                   struct{}{},
+		Year:                     struct{}{},
+		Group:                    struct{}{},
+		Title:                    struct{}{},
+		ShortDescription:         struct{}{},
+		LongDescription:          struct{}{},
+		EventType:                struct{}{},
+		GameSystem:               struct{}{},
+		RulesEdition:             struct{}{},
+		MinPlayers:               struct{}{},
+		MaxPlayers:               struct{}{},
+		AgeRequired:              struct{}{},
+		ExperienceRequired:       struct{}{},
 		MaterialsProvided:        struct{}{},
 		MaterialsRequired:        struct{}{},
 		MaterialsRequiredDetails: struct{}{},
-		StartDateTime:        struct{}{},
-		Duration:             struct{}{},
-		EndDateTime:          struct{}{},
-		GMNames:              struct{}{},
-		Website:              struct{}{},
-		Email:                struct{}{},
-		Tournament:           struct{}{},
-		RoundNumber:          struct{}{},
-		TotalRounds:          struct{}{},
-		MinimumPlayTime:      struct{}{},
-		AttendeeRegistration: struct{}{},
-		Cost:                 struct{}{},
-		Location:             struct{}{},
-		RoomName:             struct{}{},
-		TableNumber:          struct{}{},
-		SpecialCategory:      struct{}{},
-		TicketsAvailable:     struct{}{},
-		LastModified:         struct{}{},
-		AlsoRuns:             struct{}{},
-		Prize:                struct{}{},
-		RulesComplexity:      struct{}{},
-		OriginalOrder:        struct{}{},
+		StartDateTime:            struct{}{},
+		Duration:                 struct{}{},
+		EndDateTime:              struct{}{},
+		GMNames:                  struct{}{},
+		Website:                  struct{}{},
+		Email:                    struct{}{},
+		Tournament:               struct{}{},
+		RoundNumber:              struct{}{},
+		TotalRounds:              struct{}{},
+		MinimumPlayTime:          struct{}{},
+		AttendeeRegistration:     struct{}{},
+		Cost:                     struct{}{},
+		Location:                 struct{}{},
+		RoomName:                 struct{}{},
+		TableNumber:              struct{}{},
+		SpecialCategory:          struct{}{},
+		TicketsAvailable:         struct{}{},
+		LastModified:             struct{}{},
+		AlsoRuns:                 struct{}{},
+		Prize:                    struct{}{},
+		RulesComplexity:          struct{}{},
+		OriginalOrder:            struct{}{},
 	}
 )
 

--- a/internal/event/types.go
+++ b/internal/event/types.go
@@ -384,35 +384,35 @@ func FromExternal(e gcbapi.Event) (*Event, error) {
 		OriginalOrder:            e.Attributes.OriginalOrder,
 	}
 
-	if err := ValidateType(e.Attributes.EventType); err != nil {
-		return nil, fmt.Errorf("invalided event type for event %s: %w", e.ID, err)
-	}
-
-	evt.EventType = Type(e.Attributes.EventType)
-
 	if err := ValidateAgeGroup(e.Attributes.AgeRequired); err != nil {
 		return nil, fmt.Errorf("invalided event age required for event %s: %w", e.ID, err)
 	}
 
-	evt.AgeRequired = AgeGroup(e.Attributes.AgeRequired)
+	evt.AgeRequired = AgeGroupFromSearchTerm(e.Attributes.AgeRequired)
+
+	if err := ValidateType(e.Attributes.EventType); err != nil {
+		return nil, fmt.Errorf("invalided event type for event %s: %w", e.ID, err)
+	}
+
+	evt.EventType = EventTypeFromSearchTerm(e.Attributes.EventType)
 
 	if err := ValidateEXP(e.Attributes.ExperienceRequired); err != nil {
 		return nil, fmt.Errorf("invalided event experience required for event %s: %w", e.ID, err)
 	}
 
-	evt.ExperienceRequired = EXP(e.Attributes.ExperienceRequired)
+	evt.ExperienceRequired = EXPFromSearchTerm(e.Attributes.ExperienceRequired)
 
 	if err := ValidateRegistration(e.Attributes.AttendeeRegistration); err != nil {
 		return nil, fmt.Errorf("invalided event registration for event %s: %w", e.ID, err)
 	}
 
-	evt.AttendeeRegistration = Registration(e.Attributes.AttendeeRegistration)
+	evt.AttendeeRegistration = RegistrationFromSearchTerm(e.Attributes.AttendeeRegistration)
 
-	if err := ValidateCategory(e.Attributes.EventType); err != nil {
+	if err := ValidateCategory(e.Attributes.SpecialCategory); err != nil {
 		return nil, fmt.Errorf("invalided event type for event %s: %w", e.ID, err)
 	}
 
-	evt.SpecialCategory = Category(e.Attributes.EventType)
+	evt.SpecialCategory = CategoryFromSearchTerm(e.Attributes.SpecialCategory)
 
 	return evt, nil
 }

--- a/internal/search/term_keyword.go
+++ b/internal/search/term_keyword.go
@@ -12,6 +12,20 @@ type Keyword struct {
 	values []string
 }
 
+// NewKeywordSingle creates a terms query
+func NewKeywordSingle(field, val string) (Keyword, error) {
+	keyword := Keyword{}
+	if field == "" {
+		return keyword, fmt.Errorf("cannot create a keyword term without a field")
+	}
+
+	keyword.field = field
+	keyword.values = []string{val}
+
+	return keyword, nil
+}
+
+// NewKeyword creates a terms query, splitting the single string value list by ,
 func NewKeyword(field, vals string) (Keyword, error) {
 	keyword := Keyword{}
 	if field == "" {


### PR DESCRIPTION
When translating an external request to an internal reuqest, the enums were not being properly handled. Before creating the terms query, we needed to convert the external enum value to the internal value which directly relates to the csv event data values.

Issue: #3 & #13