### PR TITLE
feat(search): support filtering by multiple event types

### DIFF
--- a/internal/event/search.go
+++ b/internal/event/search.go
@@ -34,7 +34,12 @@ func NewSearchField(f string, value string) (search.Term, error) {
 	case AgeRequired:
 		return search.NewKeywordSingle(f, string(AgeGroupFromSearchTerm(value)))
 	case EventType:
-		return search.NewKeywordSingle(f, string(EventTypeFromSearchTerm(value)))
+		parts := strings.Split(value, ",")
+		converted := make([]string, len(parts))
+		for i, p := range parts {
+			converted[i] = string(EventTypeFromSearchTerm(p))
+		}
+		return search.NewKeyword(f, strings.Join(converted, ","))
 	case ExperienceRequired:
 		return search.NewKeywordSingle(f, string(EXPFromSearchTerm(value)))
 	case AttendeeRegistration:


### PR DESCRIPTION
## Summary

- `eventType` filter now accepts comma-separated values (e.g. `eventType=RPG,BGM`)
- Each value is still passed through `EventTypeFromSearchTerm` for normalization
- Single-value behavior is unchanged — existing queries are unaffected

## Test plan

- [ ] Verify single event type filter still works (e.g. `?eventType=RPG`)
- [ ] Verify multi-value filter returns events of all listed types (e.g. `?eventType=RPG,BGM`)
- [ ] Verify invalid values still resolve to `"invalid"` (no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)