### PR TITLE
feat(events): game system facets endpoint + exact-match search

### DIFF
--- a/gcbapi/event.go
+++ b/gcbapi/event.go
@@ -90,3 +90,15 @@ type EventFetchResponse struct {
 	Events []Event `json:"events,omitempty"`
 	Error  string  `json:"error,omitempty"`
 }
+
+// GameSystemFacet is a single game system value with its event count.
+type GameSystemFacet struct {
+	Value string `json:"value"`
+	Count int64  `json:"count"`
+}
+
+// GameSystemFacetsResponse is the response for GET /api/events/facets/gameSystem.
+type GameSystemFacetsResponse struct {
+	Values []GameSystemFacet `json:"values,omitempty"`
+	Error  string            `json:"error,omitempty"`
+}

--- a/gcbapi/event.go
+++ b/gcbapi/event.go
@@ -91,14 +91,14 @@ type EventFetchResponse struct {
 	Error  string  `json:"error,omitempty"`
 }
 
-// GameSystemFacet is a single game system value with its event count.
-type GameSystemFacet struct {
+// KeywordFacet is a single keyword field value with its event count.
+type KeywordFacet struct {
 	Value string `json:"value"`
 	Count int64  `json:"count"`
 }
 
-// GameSystemFacetsResponse is the response for GET /api/events/facets/gameSystem.
-type GameSystemFacetsResponse struct {
-	Values []GameSystemFacet `json:"values,omitempty"`
-	Error  string            `json:"error,omitempty"`
+// KeywordFacetsResponse is the response for facet endpoints.
+type KeywordFacetsResponse struct {
+	Values []KeywordFacet `json:"values,omitempty"`
+	Error  string         `json:"error,omitempty"`
 }

--- a/internal/api/event_handler.go
+++ b/internal/api/event_handler.go
@@ -49,7 +49,9 @@ func (e *EventHandler) Register() {
 
 	e.ws.Route(e.ws.GET("/facets/gameSystem").To(e.GameSystemFacets).
 		Doc("Get all distinct game system values with event counts").
-		Writes(gcbapi.GameSystemFacetsResponse{}))
+		Writes(gcbapi.KeywordFacetsResponse{}).
+		Param(e.ws.QueryParameter("size", "Maximum number of values to return. Default is 100, max is 5000.").
+			DataType("int").DefaultValue("100")))
 
 	restful.Add(e.ws)
 }
@@ -190,16 +192,34 @@ func (e *EventHandler) Search(req *restful.Request, resp *restful.Response) {
 
 // GameSystemFacets handles GET /api/events/facets/gameSystem
 func (e *EventHandler) GameSystemFacets(req *restful.Request, resp *restful.Response) {
-	facets, err := e.manager.GetGameSystemFacets(req.Request.Context())
+	const maxSize = 5000
+	size := 100
+
+	if sizeParam := req.QueryParameter("size"); sizeParam != "" {
+		parsed, err := strconv.Atoi(sizeParam)
+		if err != nil || parsed < 1 {
+			resp.WriteHeader(http.StatusBadRequest)
+			resp.Write([]byte(`{"error":"size must be a positive integer"}`))
+			return
+		}
+		if parsed > maxSize {
+			resp.WriteHeader(http.StatusBadRequest)
+			resp.Write([]byte(`{"error":"size cannot exceed 5000"}`))
+			return
+		}
+		size = parsed
+	}
+
+	facets, err := e.manager.GetKeywordFacets(req.Request.Context(), "gameSystem.keyword", size)
 	if err != nil {
 		e.logger.Err(err).Msg("failed to get game system facets")
-		body, _ := json.Marshal(gcbapi.GameSystemFacetsResponse{Error: "failed to retrieve game system facets"})
+		body, _ := json.Marshal(gcbapi.KeywordFacetsResponse{Error: "failed to retrieve game system facets"})
 		resp.WriteHeader(http.StatusInternalServerError)
 		resp.Write(body)
 		return
 	}
 
-	body, err := json.Marshal(gcbapi.GameSystemFacetsResponse{Values: facets})
+	body, err := json.Marshal(gcbapi.KeywordFacetsResponse{Values: facets})
 	if err != nil {
 		e.logger.Err(err).Msg("failed to marshal game system facets response")
 		resp.WriteHeader(http.StatusInternalServerError)

--- a/internal/api/event_handler.go
+++ b/internal/api/event_handler.go
@@ -47,6 +47,10 @@ func (e *EventHandler) Register() {
 		Param(e.ws.QueryParameter("sort", "What field to sert the events on formatted by {field name}.{asc|desc}. Can sort by any field in the event.").
 			DataType("string").DefaultValue("")))
 
+	e.ws.Route(e.ws.GET("/facets/gameSystem").To(e.GameSystemFacets).
+		Doc("Get all distinct game system values with event counts").
+		Writes(gcbapi.GameSystemFacetsResponse{}))
+
 	restful.Add(e.ws)
 }
 
@@ -182,4 +186,27 @@ func (e *EventHandler) Search(req *restful.Request, resp *restful.Response) {
 	}
 
 	resp.WriteHeader(http.StatusOK)
+}
+
+// GameSystemFacets handles GET /api/events/facets/gameSystem
+func (e *EventHandler) GameSystemFacets(req *restful.Request, resp *restful.Response) {
+	facets, err := e.manager.GetGameSystemFacets(req.Request.Context())
+	if err != nil {
+		e.logger.Err(err).Msg("failed to get game system facets")
+		body, _ := json.Marshal(gcbapi.GameSystemFacetsResponse{Error: "failed to retrieve game system facets"})
+		resp.WriteHeader(http.StatusInternalServerError)
+		resp.Write(body)
+		return
+	}
+
+	body, err := json.Marshal(gcbapi.GameSystemFacetsResponse{Values: facets})
+	if err != nil {
+		e.logger.Err(err).Msg("failed to marshal game system facets response")
+		resp.WriteHeader(http.StatusInternalServerError)
+		resp.Write([]byte(`{"error":"failed to write response"}`))
+		return
+	}
+
+	resp.WriteHeader(http.StatusOK)
+	resp.Write(body)
 }

--- a/internal/api/event_manager.go
+++ b/internal/api/event_manager.go
@@ -22,6 +22,20 @@ func NewEventManager(logger *zerolog.Logger, repo *event.EventRepo) EventManager
 	}
 }
 
+// GetGameSystemFacets returns all distinct game system values with their event counts.
+func (m EventManager) GetGameSystemFacets(ctx context.Context) ([]gcbapi.GameSystemFacet, error) {
+	facets, err := m.repo.GetGameSystemFacets(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]gcbapi.GameSystemFacet, len(facets))
+	for i, f := range facets {
+		result[i] = gcbapi.GameSystemFacet{Value: f.Value, Count: f.Count}
+	}
+	return result, nil
+}
+
 // Search for events given the search request
 func (m EventManager) Search(ctx context.Context, search event.SearchRequest) (int64, []gcbapi.Event, error) {
 	resp, err := m.repo.Search(ctx, search)

--- a/internal/api/event_manager.go
+++ b/internal/api/event_manager.go
@@ -22,16 +22,16 @@ func NewEventManager(logger *zerolog.Logger, repo *event.EventRepo) EventManager
 	}
 }
 
-// GetGameSystemFacets returns all distinct game system values with their event counts.
-func (m EventManager) GetGameSystemFacets(ctx context.Context) ([]gcbapi.GameSystemFacet, error) {
-	facets, err := m.repo.GetGameSystemFacets(ctx)
+// GetKeywordFacets returns distinct values and counts for any keyword field or subfield.
+func (m EventManager) GetKeywordFacets(ctx context.Context, field string, size int) ([]gcbapi.KeywordFacet, error) {
+	facets, err := m.repo.GetKeywordFacets(ctx, field, size)
 	if err != nil {
 		return nil, err
 	}
 
-	result := make([]gcbapi.GameSystemFacet, len(facets))
+	result := make([]gcbapi.KeywordFacet, len(facets))
 	for i, f := range facets {
-		result[i] = gcbapi.GameSystemFacet{Value: f.Value, Count: f.Count}
+		result[i] = gcbapi.KeywordFacet{Value: f.Value, Count: f.Count}
 	}
 	return result, nil
 }

--- a/internal/event/repo.go
+++ b/internal/event/repo.go
@@ -288,20 +288,23 @@ func (r *EventRepo) Search(ctx context.Context, req SearchRequest) (SearchRespon
 	}, nil
 }
 
-// GameSystemFacet is a single aggregation bucket from OpenSearch.
-type GameSystemFacet struct {
+// KeywordFacet is a single aggregation bucket from OpenSearch.
+type KeywordFacet struct {
 	Value string
 	Count int64
 }
 
-func (r *EventRepo) GetGameSystemFacets(ctx context.Context) ([]GameSystemFacet, error) {
+// GetKeywordFacets returns distinct values and counts for any keyword (or keyword subfield) in the index.
+// field should be a keyword field or a .keyword subfield (e.g. "gameSystem.keyword").
+// size controls the maximum number of buckets returned.
+func (r *EventRepo) GetKeywordFacets(ctx context.Context, field string, size int) ([]KeywordFacet, error) {
 	body := map[string]any{
 		"size": 0,
 		"aggs": map[string]any{
-			"game_systems": map[string]any{
+			"facet_values": map[string]any{
 				"terms": map[string]any{
-					"field": "gameSystem.keyword",
-					"size":  5000,
+					"field": field,
+					"size":  size,
 					"order": map[string]any{"_key": "asc"},
 				},
 			},
@@ -335,12 +338,12 @@ func (r *EventRepo) GetGameSystemFacets(ctx context.Context) ([]GameSystemFacet,
 
 	var raw struct {
 		Aggregations struct {
-			GameSystems struct {
+			FacetValues struct {
 				Buckets []struct {
 					Key      string `json:"key"`
 					DocCount int64  `json:"doc_count"`
 				} `json:"buckets"`
-			} `json:"game_systems"`
+			} `json:"facet_values"`
 		} `json:"aggregations"`
 	}
 
@@ -352,12 +355,12 @@ func (r *EventRepo) GetGameSystemFacets(ctx context.Context) ([]GameSystemFacet,
 		return nil, fmt.Errorf("failed to unmarshal facet response: %w", err)
 	}
 
-	var facets []GameSystemFacet
-	for _, b := range raw.Aggregations.GameSystems.Buckets {
+	var facets []KeywordFacet
+	for _, b := range raw.Aggregations.FacetValues.Buckets {
 		if b.Key == "" {
 			continue
 		}
-		facets = append(facets, GameSystemFacet{Value: b.Key, Count: b.DocCount})
+		facets = append(facets, KeywordFacet{Value: b.Key, Count: b.DocCount})
 	}
 	return facets, nil
 }

--- a/internal/event/repo.go
+++ b/internal/event/repo.go
@@ -288,6 +288,80 @@ func (r *EventRepo) Search(ctx context.Context, req SearchRequest) (SearchRespon
 	}, nil
 }
 
+// GameSystemFacet is a single aggregation bucket from OpenSearch.
+type GameSystemFacet struct {
+	Value string
+	Count int64
+}
+
+func (r *EventRepo) GetGameSystemFacets(ctx context.Context) ([]GameSystemFacet, error) {
+	body := map[string]any{
+		"size": 0,
+		"aggs": map[string]any{
+			"game_systems": map[string]any{
+				"terms": map[string]any{
+					"field": "gameSystem.keyword",
+					"size":  5000,
+					"order": map[string]any{"_key": "asc"},
+				},
+			},
+		},
+	}
+
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal facet request: %w", err)
+	}
+
+	osReq := opensearchapi.SearchRequest{
+		Index: []string{r.eventIndex},
+		Body:  bytes.NewReader(bodyBytes),
+	}
+
+	osResp, err := osReq.Do(ctx, r.client)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := osResp.Body.Close(); err != nil {
+			r.logger.Err(err).Msg("failed to close facet response body")
+		}
+	}()
+
+	if osResp.IsError() {
+		r.logger.Error().Msgf("facet request failed. Raw response: %s", osResp.String())
+		return nil, fmt.Errorf("failed facet request %d", osResp.StatusCode)
+	}
+
+	var raw struct {
+		Aggregations struct {
+			GameSystems struct {
+				Buckets []struct {
+					Key      string `json:"key"`
+					DocCount int64  `json:"doc_count"`
+				} `json:"buckets"`
+			} `json:"game_systems"`
+		} `json:"aggregations"`
+	}
+
+	buff := bytes.NewBuffer([]byte{})
+	if _, err := buff.ReadFrom(osResp.Body); err != nil {
+		return nil, fmt.Errorf("failed to read facet response body: %w", err)
+	}
+	if err := json.Unmarshal(buff.Bytes(), &raw); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal facet response: %w", err)
+	}
+
+	var facets []GameSystemFacet
+	for _, b := range raw.Aggregations.GameSystems.Buckets {
+		if b.Key == "" {
+			continue
+		}
+		facets = append(facets, GameSystemFacet{Value: b.Key, Count: b.DocCount})
+	}
+	return facets, nil
+}
+
 func (r *EventRepo) FetchEvents(ctx context.Context, ids ...string) (FetchEventsResponse, error) {
 	if len(ids) == 0 {
 		return FetchEventsResponse{

--- a/internal/event/search.go
+++ b/internal/event/search.go
@@ -47,8 +47,11 @@ func NewSearchField(f string, value string) (search.Term, error) {
 	case SpecialCategory:
 		return search.NewKeywordSingle(f, string(CategoryFromSearchTerm(value)))
 	// Keywords that have no special consideration
-	case GameID, MaterialsRequired, LastChangeLogModification, GameSystem:
+	case GameID, MaterialsRequired, LastChangeLogModification:
 		return search.NewKeyword(f, value)
+	// GameSystem is a text field with a .keyword subfield; exact match requires the subfield
+	case GameSystem:
+		return search.NewKeyword(f+".keyword", value)
 	// integer
 	case Year, MinPlayers, MaxPlayers, RoundNumber,
 		TotalRounds, TicketsAvailable, TotalTickets:

--- a/internal/event/search.go
+++ b/internal/event/search.go
@@ -47,14 +47,14 @@ func NewSearchField(f string, value string) (search.Term, error) {
 	case SpecialCategory:
 		return search.NewKeywordSingle(f, string(CategoryFromSearchTerm(value)))
 	// Keywords that have no special consideration
-	case GameID, MaterialsRequired, LastChangeLogModification:
+	case GameID, MaterialsRequired, LastChangeLogModification, GameSystem:
 		return search.NewKeyword(f, value)
 	// integer
 	case Year, MinPlayers, MaxPlayers, RoundNumber,
 		TotalRounds, TicketsAvailable, TotalTickets:
 		return search.NewNumber(f, value)
 	// Generic full text search fields
-	case Group, Title, ShortDescription, LongDescription, GameSystem,
+	case Group, Title, ShortDescription, LongDescription,
 		RulesEdition, MaterialsProvided, MaterialsRequiredDetails, GMNames, Tournament,
 		Location, RoomName, TableNumber, Prize, RulesComplexity:
 		return search.NewText(f, value)


### PR DESCRIPTION
## Summary

- Adds `GET /api/events/facets/gameSystem` — returns all distinct game system values with event counts, backed by an OpenSearch `terms` aggregation on `gameSystem.keyword`
- Switches `gameSystem` search from full-text `match` to exact keyword `term`/`terms` query, aligning with the typeahead UI that will guide users to valid values

## Response shape

```json
{
  "values": [
    { "value": "Dungeons & Dragons 5E", "count": 142 },
    { "value": "Pathfinder 2E", "count": 87 }
  ]
}
```

## Breaking change

Partial/fuzzy `gameSystem` query params (e.g. `?gameSystem=dungeons`) no longer match. Only exact values from the facet endpoint work. This is intentional — the typeahead replaces free-text input.

## Test plan

- [ ] `GET /api/events/facets/gameSystem` returns 200 with sorted values and counts
- [ ] Empty/blank game system values are excluded from the response
- [ ] `?gameSystem=Dungeons+%26+Dragons+5E` (exact) still returns results
- [ ] `?gameSystem=dungeons` (partial) no longer matches
- [ ] Multiple values `?gameSystem=Dungeons+%26+Dragons+5E,Pathfinder+2E` returns OR results

🤖 Generated with [Claude Code](https://claude.com/claude-code)