### PR TITLE
feat: add event hydrator pattern

### DIFF
--- a/cmd/data/initialize/init.go
+++ b/cmd/data/initialize/init.go
@@ -78,24 +78,24 @@ func run(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	var evts []*event.Event
+	var eventReader event.Reader
 
 	if strings.HasSuffix(filepath, ".csv") {
-		evts, err = event.LoadEventCSV(cmd.Context(), filepath, gcb.Logger)
+		eventReader, err = event.NewCSVReader(gcb.Logger, filepath)
 	} else if strings.HasSuffix(filepath, ".xlsx") {
-		evts, err = event.LoadEventXLSX(cmd.Context(), filepath, gcb.Logger)
+		eventReader, err = event.NewXLSXReader(gcb.Logger, event.XLSXFileOptions{Filepath: filepath})
 	} else {
 		return fmt.Errorf("unknown file type in filepath: %s", filepath)
 	}
 
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to setup event reader: %w", err)
 	}
 
-	// When writing the events for the first time, take the `ticketsAvailable`
-	// as the total ticket pool
-	for _, e := range evts {
-		e.TotalTickets = e.TicketsAvailable
+	// TODO pass along the bgg data hydrator
+	evts, err := eventReader.ReadEvents(cmd.Context(), event.HydrateTotalTickets{})
+	if err != nil {
+		return fmt.Errorf("failed to read events: %w", err)
 	}
 
 	eventErrs, err := gcb.EventRepo.CreateEvents(cmd.Context(), evts)

--- a/cmd/data/update.go
+++ b/cmd/data/update.go
@@ -15,7 +15,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/wI2L/jsondiff"
-	"github.com/xuri/excelize/v2"
 )
 
 const (
@@ -59,15 +58,15 @@ func update(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to load gcp app context")
 	}
 
-	var events []*event.Event
+	var eventReader event.Reader
 
 	if downloadURL != defaultDownloadURL {
-		events, err = downloadEvents(cmd.Context(), gcb, downloadURL)
+		eventReader, err = setupEventReaderFromDownload(gcb, downloadURL)
 	} else {
 		if strings.HasSuffix(localFilepath, ".csv") {
-			events, err = event.LoadEventCSV(cmd.Context(), localFilepath, gcb.Logger)
+			eventReader, err = event.NewCSVReader(gcb.Logger, localFilepath)
 		} else if strings.HasSuffix(localFilepath, ".xlsx") {
-			events, err = event.LoadEventXLSX(cmd.Context(), localFilepath, gcb.Logger)
+			eventReader, err = event.NewXLSXReader(gcb.Logger, event.XLSXFileOptions{Filepath: localFilepath})
 		} else {
 			return fmt.Errorf("unknown file type in filepath: %s", localFilepath)
 		}
@@ -77,14 +76,17 @@ func update(cmd *cobra.Command, _ []string) error {
 		gcb.Logger.Err(err).
 			Str("download_url", downloadURL).
 			Str("local_file", localFilepath).
-			Msg("failed to read in the event list for updating")
-		return fmt.Errorf("failed to fetch event list for updating: %w", err)
+			Msg("failed to build event reader")
+		return fmt.Errorf("failed to build event reader: %w", err)
 	}
+
+	// TODO pass in bgg hydrator
+	events, err := eventReader.ReadEvents(cmd.Context())
 
 	return processChangeLogEvents(cmd.Context(), gcb, events)
 }
 
-func downloadEvents(ctx context.Context, gcb *app.App, downloadURL string) ([]*event.Event, error) {
+func setupEventReaderFromDownload(gcb *app.App, downloadURL string) (event.Reader, error) {
 	gcb.Logger.Info().Str("url", downloadURL).Msg("Fetching events from download page.")
 
 	resp, err := http.Get(downloadURL)
@@ -102,12 +104,7 @@ func downloadEvents(ctx context.Context, gcb *app.App, downloadURL string) ([]*e
 		}
 	}()
 
-	f, err := excelize.OpenReader(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response from [%s]: %w", downloadURL, err)
-	}
-
-	return event.ReadEventsFromXLSX(ctx, gcb.Logger, f)
+	return event.NewXLSXReader(gcb.Logger, event.XLSXFileOptions{Reader: resp.Body})
 }
 
 func processChangeLogEvents(ctx context.Context, gcb *app.App, eventList []*event.Event) error {
@@ -210,6 +207,8 @@ func processChangeLogBatch(ctx context.Context, gcb *app.App, clEntry *changelog
 				Str("change_log_entry_id", clEntry.ID).
 				Msg("Event listed in list to fetch, but not the batch of events provided. Skipping")
 		} else {
+			// New events need their total tickets set to the available count
+			e.TotalTickets = e.TicketsAvailable
 			writeEvents = append(writeEvents, e)
 			clEntry.CreatedEvents = append(clEntry.CreatedEvents, id)
 		}

--- a/internal/api/change_log_handler.go
+++ b/internal/api/change_log_handler.go
@@ -93,7 +93,7 @@ func (c *ChangeLogHandler) ListChangeLogs(req *restful.Request, resp *restful.Re
 			i, err := strconv.Atoi(values[0])
 			if err != nil {
 				resp.WriteHeader(http.StatusBadRequest)
-				response.Error = fmt.Sprintf("invalid integer for limti: %w", err)
+				response.Error = fmt.Sprintf("invalid integer for limti: %s", err)
 				return
 			}
 

--- a/internal/event/hydrator.go
+++ b/internal/event/hydrator.go
@@ -1,0 +1,23 @@
+package event
+
+// Hydrator adds additional information to an event
+type Hydrator interface {
+	// Hydrate modifies the provided event, adding extra information as applicable
+	Hydrate(*Event) error
+	// Name of the hydrator, used for logging
+	Name() string
+}
+
+// HydrateTotalTickets is used when the events are first created to set their initial ticket count.
+type HydrateTotalTickets struct{}
+
+// Hydrate ...
+func (h HydrateTotalTickets) Hydrate(e *Event) error {
+	e.TotalTickets = e.TicketsAvailable
+	return nil
+}
+
+// Name ...
+func (h HydrateTotalTickets) Name() string {
+	return "HydrateTotalTickets"
+}

--- a/internal/event/parser.go
+++ b/internal/event/parser.go
@@ -1,0 +1,75 @@
+package event
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rs/zerolog"
+)
+
+// Parser reads in an order list of string fields, and converts those to an event.
+// A Parser will collect data validation errors as an aggregate based on the error string.
+type Parser interface {
+	Parse([]string) (*Event, error)
+	DataErrors() map[string]int
+}
+
+// HeaderParser implements the parser interface with a defined set of headers.
+// The headers are mapped to the internal event fields.
+type HeaderParser struct {
+	logger zerolog.Logger
+	// maps the expected field order to event fields, based on the header order
+	indexToFieldMap map[int]string
+	dataErrors      map[string]int
+}
+
+// NewHeaderedParser instantiates a HeaderedParser
+func NewHeaderedParser(logger zerolog.Logger, headers []string) *HeaderParser {
+	indexToFieldMap := make(map[int]string, len(headers[0]))
+	for index, header := range headers {
+		lcHeader := strings.ToLower(header)
+		if field, ok := headersToFields[lcHeader]; ok {
+			logger.Debug().Msgf("Header [%s] to event field [%s]", header, field)
+			indexToFieldMap[index] = field
+		} else {
+			logger.Warn().Msgf("Failed to find an appropriate field for header %s", header)
+		}
+	}
+
+	return &HeaderParser{
+		logger:          logger,
+		indexToFieldMap: indexToFieldMap,
+		dataErrors:      make(map[string]int),
+	}
+}
+
+// Parse the ordered field list into an event
+func (h *HeaderParser) Parse(fields []string) (*Event, error) {
+	var (
+		newEvent = &Event{}
+	)
+
+	for index, value := range fields {
+		if field, ok := h.indexToFieldMap[index]; !ok {
+			h.logger.Debug().Msgf("XLSX index %d did not match any field", index)
+		} else {
+			if err := newEvent.SetFieldFromString(field, value); err != nil {
+				// logger.Warn().Str("field", field).Str("value", value).Msg("Validation error")
+				err = fmt.Errorf("validation error for field [%s]: %s", field, err)
+				h.dataErrors[err.Error()] = h.dataErrors[err.Error()] + 1
+			}
+		}
+	}
+
+	if newEvent.GameID == "" {
+		h.logger.Warn().Msgf("Invalid event field set: %v", fields)
+		return nil, fmt.Errorf("failed to parse event")
+	}
+
+	return newEvent, nil
+}
+
+// DataErrosr returns the collected data error aggregations so far
+func (h *HeaderParser) DataErrors() map[string]int {
+	return h.dataErrors
+}

--- a/internal/event/reader.go
+++ b/internal/event/reader.go
@@ -59,6 +59,203 @@ var (
 	}
 )
 
+// Reader reads in Events
+type Reader interface {
+	// ReadEvents reads all of the events from the reader
+	ReadEvents(context.Context, ...Hydrator) ([]*Event, error)
+	// Close the file used for reading
+	Close() error
+}
+
+// CSVReader reads events from a csv file
+type CSVReader struct {
+	logger    zerolog.Logger
+	parser    Parser
+	file      *os.File
+	csvReader *csv.Reader
+}
+
+// NewCSVReader opens the provided filepath and instantiates an CSVReader
+func NewCSVReader(logger zerolog.Logger, filepath string) (*CSVReader, error) {
+	logger.Info().Msgf("Loading event csv %s", filepath)
+
+	eventFile, err := os.Open(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open csv file: %w", err)
+	}
+
+	eventReader := csv.NewReader(transform.NewReader(eventFile, charmap.Windows1252.NewDecoder()))
+	headers, err := eventReader.Read()
+	if err == io.EOF {
+		return nil, fmt.Errorf("event csv file empty")
+	}
+
+	return &CSVReader{
+		logger:    logger,
+		parser:    NewHeaderedParser(logger, headers),
+		file:      eventFile,
+		csvReader: eventReader,
+	}, nil
+}
+
+// ReadEvents from the csv file
+func (c *CSVReader) ReadEvents(ctx context.Context, hydrators ...Hydrator) ([]*Event, error) {
+	if c.csvReader == nil {
+		return nil, nil
+	}
+
+	var (
+		events = make([]*Event, 0)
+		err    error
+		row    []string
+	)
+
+	for {
+		row, err = c.csvReader.Read()
+		if err != nil {
+			break
+		}
+
+		e, err := c.parser.Parse(row)
+		if err != nil {
+			c.logger.Err(err).Msgf("failed to parse row of csv file")
+			continue
+		}
+
+		for _, h := range hydrators {
+			if err := h.Hydrate(e); err != nil {
+				c.logger.Err(err).
+					Str("hydrator", h.Name()).
+					Msg("failed to hydrate the event")
+			}
+		}
+
+		events = append(events, e)
+	}
+
+	for e, count := range c.parser.DataErrors() {
+		c.logger.Warn().Msgf("Found data validation %d times | %s", count, e)
+	}
+
+	if err != io.EOF {
+		return nil, err
+	}
+
+	return events, nil
+}
+
+// Close the csv file used by the CSVReader
+func (c *CSVReader) Close() error {
+	if c.file != nil {
+		return c.file.Close()
+	}
+
+	return nil
+}
+
+// XLSXReader reads events from an xlsx file
+type XLSXReader struct {
+	logger zerolog.Logger
+	parser Parser
+	rows   *[][]string
+}
+
+// XLSXFileOptions configures the XLSXReader to either use an io.Reader or read directly from a file
+type XLSXFileOptions struct {
+	Filepath string
+	Reader   io.Reader
+}
+
+// NewXLSXReader opens the provided file and validates the headers before it can begin reading
+func NewXLSXReader(logger zerolog.Logger, fileOptions XLSXFileOptions) (*XLSXReader, error) {
+	var (
+		f   *excelize.File
+		err error
+	)
+
+	if fileOptions.Filepath != "" {
+		logger.Info().Msgf("Loading event file %s", fileOptions.Filepath)
+		f, err = excelize.OpenFile(fileOptions.Filepath)
+	} else {
+		logger.Info().Msgf("Loading events from io.reader")
+		f, err = excelize.OpenReader(fileOptions.Reader)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to open excel file: %w", err)
+	}
+
+	defer func() {
+		// Close the spreadsheet.
+		if err := f.Close(); err != nil {
+			logger.Err(err).Msg("Failed to close event xlsx")
+		}
+	}()
+
+	if f.SheetCount > 1 {
+		logger.Warn().Msgf("expecting a single sheet in the event file, but found [%d]. Using the first sheet.", f.SheetCount)
+	}
+
+	sheetName := f.GetSheetName(0)
+	rows, err := f.GetRows(sheetName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read the rows from the sheet [%s]: %w", sheetName, err)
+	}
+
+	if len(rows) <= 1 {
+		return nil, fmt.Errorf("invalid event file, not enough rows: %d", len(rows))
+	}
+
+	return &XLSXReader{
+		logger: logger,
+		parser: NewHeaderedParser(logger, rows[0]),
+		rows:   &rows,
+	}, nil
+}
+
+// ReadEvents from the excel file
+func (x *XLSXReader) ReadEvents(ctx context.Context, hydrators ...Hydrator) ([]*Event, error) {
+	if x.rows == nil {
+		return nil, nil
+	}
+
+	if len(*x.rows) <= 1 {
+		return nil, nil
+	}
+
+	events := make([]*Event, len(*x.rows)-1, 0)
+
+	for i := 1; i < len(*x.rows); i++ {
+		row := (*x.rows)[i]
+		e, err := x.parser.Parse(row)
+		if err != nil {
+			x.logger.Err(err).Msgf("failed to parse row %d of excel file", i)
+			continue
+		}
+
+		for _, h := range hydrators {
+			if err := h.Hydrate(e); err != nil {
+				x.logger.Err(err).
+					Str("hydrator", h.Name()).
+					Msg("failed to hydrate the event")
+			}
+		}
+
+		events = append(events, e)
+	}
+
+	for e, count := range x.parser.DataErrors() {
+		x.logger.Warn().Msgf("Found data validation %d times | %s", count, e)
+	}
+
+	return events, nil
+}
+
+func (x *XLSXReader) Close() error {
+	// XLSReader only uses the file in the constructor, so it closes it then
+	return nil
+}
+
 func LoadEventXLSX(ctx context.Context, filepath string, logger zerolog.Logger) ([]*Event, error) {
 	logger.Info().Msgf("Loading event xlsx %s", filepath)
 	f, err := excelize.OpenFile(filepath)


### PR DESCRIPTION
Refactored the event loading and parsing to have a unified interface, `event.Parser`. This allows a consistent way to pass in hydrators to add data as needed. The initial example is the `HydrateTotalTicket` hydrator to set the initial total ticket value.