### PR TITLE
feat(events): unified /facets/{field} endpoint with support for 8 fields

### DIFF
--- a/internal/api/event_handler.go
+++ b/internal/api/event_handler.go
@@ -189,12 +189,18 @@ func (e *EventHandler) Search(req *restful.Request, resp *restful.Response) {
 	resp.WriteHeader(http.StatusOK)
 }
 
-// facetFields maps supported facet field names to their OpenSearch keyword subfield.
+// facetFields maps supported facet field names to their OpenSearch field.
+// Text fields with a .keyword subfield use the subfield for exact aggregation;
+// enum fields are stored as keyword type and are queried directly.
 var facetFields = map[string]string{
-	"gameSystem": "gameSystem.keyword",
-	"group":      "group.keyword",
-	"location":   "location.keyword",
-	"roomName":   "roomName.keyword",
+	"gameSystem":           "gameSystem.keyword",
+	"group":                "group.keyword",
+	"location":             "location.keyword",
+	"roomName":             "roomName.keyword",
+	"ageRequired":          "ageRequired",
+	"experienceRequired":   "experienceRequired",
+	"attendeeRegistration": "attendeeRegistration",
+	"specialCategory":      "specialCategory",
 }
 
 // Facets handles GET /api/events/facets/{field}

--- a/internal/api/event_handler.go
+++ b/internal/api/event_handler.go
@@ -53,6 +53,24 @@ func (e *EventHandler) Register() {
 		Param(e.ws.QueryParameter("size", "Maximum number of values to return. Default is 100, max is 5000.").
 			DataType("int").DefaultValue("100")))
 
+	e.ws.Route(e.ws.GET("/facets/group").To(e.GroupFacets).
+		Doc("Get all distinct group values with event counts").
+		Writes(gcbapi.KeywordFacetsResponse{}).
+		Param(e.ws.QueryParameter("size", "Maximum number of values to return. Default is 100, max is 5000.").
+			DataType("int").DefaultValue("100")))
+
+	e.ws.Route(e.ws.GET("/facets/location").To(e.LocationFacets).
+		Doc("Get all distinct location values with event counts").
+		Writes(gcbapi.KeywordFacetsResponse{}).
+		Param(e.ws.QueryParameter("size", "Maximum number of values to return. Default is 100, max is 5000.").
+			DataType("int").DefaultValue("100")))
+
+	e.ws.Route(e.ws.GET("/facets/roomName").To(e.RoomNameFacets).
+		Doc("Get all distinct room name values with event counts").
+		Writes(gcbapi.KeywordFacetsResponse{}).
+		Param(e.ws.QueryParameter("size", "Maximum number of values to return. Default is 100, max is 5000.").
+			DataType("int").DefaultValue("100")))
+
 	restful.Add(e.ws)
 }
 
@@ -185,6 +203,129 @@ func (e *EventHandler) Search(req *restful.Request, resp *restful.Response) {
 	}
 
 	resp.WriteHeader(http.StatusOK)
+}
+
+// GroupFacets handles GET /api/events/facets/group
+func (e *EventHandler) GroupFacets(req *restful.Request, resp *restful.Response) {
+	const maxSize = 5000
+	size := 100
+
+	if sizeParam := req.QueryParameter("size"); sizeParam != "" {
+		parsed, err := strconv.Atoi(sizeParam)
+		if err != nil || parsed < 1 {
+			resp.WriteHeader(http.StatusBadRequest)
+			resp.Write([]byte(`{"error":"size must be a positive integer"}`))
+			return
+		}
+		if parsed > maxSize {
+			resp.WriteHeader(http.StatusBadRequest)
+			resp.Write([]byte(`{"error":"size cannot exceed 5000"}`))
+			return
+		}
+		size = parsed
+	}
+
+	facets, err := e.manager.GetKeywordFacets(req.Request.Context(), "group.keyword", size)
+	if err != nil {
+		e.logger.Err(err).Msg("failed to get group facets")
+		body, _ := json.Marshal(gcbapi.KeywordFacetsResponse{Error: "failed to retrieve group facets"})
+		resp.WriteHeader(http.StatusInternalServerError)
+		resp.Write(body)
+		return
+	}
+
+	body, err := json.Marshal(gcbapi.KeywordFacetsResponse{Values: facets})
+	if err != nil {
+		e.logger.Err(err).Msg("failed to marshal group facets response")
+		resp.WriteHeader(http.StatusInternalServerError)
+		resp.Write([]byte(`{"error":"failed to write response"}`))
+		return
+	}
+
+	resp.WriteHeader(http.StatusOK)
+	resp.Write(body)
+}
+
+// LocationFacets handles GET /api/events/facets/location
+func (e *EventHandler) LocationFacets(req *restful.Request, resp *restful.Response) {
+	const maxSize = 5000
+	size := 100
+
+	if sizeParam := req.QueryParameter("size"); sizeParam != "" {
+		parsed, err := strconv.Atoi(sizeParam)
+		if err != nil || parsed < 1 {
+			resp.WriteHeader(http.StatusBadRequest)
+			resp.Write([]byte(`{"error":"size must be a positive integer"}`))
+			return
+		}
+		if parsed > maxSize {
+			resp.WriteHeader(http.StatusBadRequest)
+			resp.Write([]byte(`{"error":"size cannot exceed 5000"}`))
+			return
+		}
+		size = parsed
+	}
+
+	facets, err := e.manager.GetKeywordFacets(req.Request.Context(), "location.keyword", size)
+	if err != nil {
+		e.logger.Err(err).Msg("failed to get location facets")
+		body, _ := json.Marshal(gcbapi.KeywordFacetsResponse{Error: "failed to retrieve location facets"})
+		resp.WriteHeader(http.StatusInternalServerError)
+		resp.Write(body)
+		return
+	}
+
+	body, err := json.Marshal(gcbapi.KeywordFacetsResponse{Values: facets})
+	if err != nil {
+		e.logger.Err(err).Msg("failed to marshal location facets response")
+		resp.WriteHeader(http.StatusInternalServerError)
+		resp.Write([]byte(`{"error":"failed to write response"}`))
+		return
+	}
+
+	resp.WriteHeader(http.StatusOK)
+	resp.Write(body)
+}
+
+// RoomNameFacets handles GET /api/events/facets/roomName
+func (e *EventHandler) RoomNameFacets(req *restful.Request, resp *restful.Response) {
+	const maxSize = 5000
+	size := 100
+
+	if sizeParam := req.QueryParameter("size"); sizeParam != "" {
+		parsed, err := strconv.Atoi(sizeParam)
+		if err != nil || parsed < 1 {
+			resp.WriteHeader(http.StatusBadRequest)
+			resp.Write([]byte(`{"error":"size must be a positive integer"}`))
+			return
+		}
+		if parsed > maxSize {
+			resp.WriteHeader(http.StatusBadRequest)
+			resp.Write([]byte(`{"error":"size cannot exceed 5000"}`))
+			return
+		}
+		size = parsed
+	}
+
+	facets, err := e.manager.GetKeywordFacets(req.Request.Context(), "roomName.keyword", size)
+	if err != nil {
+		e.logger.Err(err).Msg("failed to get room name facets")
+		body, _ := json.Marshal(gcbapi.KeywordFacetsResponse{Error: "failed to retrieve room name facets"})
+		resp.WriteHeader(http.StatusInternalServerError)
+		resp.Write(body)
+		return
+	}
+
+	body, err := json.Marshal(gcbapi.KeywordFacetsResponse{Values: facets})
+	if err != nil {
+		e.logger.Err(err).Msg("failed to marshal room name facets response")
+		resp.WriteHeader(http.StatusInternalServerError)
+		resp.Write([]byte(`{"error":"failed to write response"}`))
+		return
+	}
+
+	resp.WriteHeader(http.StatusOK)
+	resp.Write(body)
 }
 
 // GameSystemFacets handles GET /api/events/facets/gameSystem

--- a/internal/api/event_handler.go
+++ b/internal/api/event_handler.go
@@ -47,27 +47,11 @@ func (e *EventHandler) Register() {
 		Param(e.ws.QueryParameter("sort", "Sort events by one or more fields as comma-separated {field}.{asc|desc} pairs (e.g., startDateTime.asc,title.desc).").
 			DataType("string").DefaultValue("")))
 
-	e.ws.Route(e.ws.GET("/facets/gameSystem").To(e.GameSystemFacets).
-		Doc("Get all distinct game system values with event counts").
+	e.ws.Route(e.ws.GET("/facets/{field}").To(e.Facets).
+		Doc("Get all distinct values with event counts for a supported keyword field").
 		Writes(gcbapi.KeywordFacetsResponse{}).
-		Param(e.ws.QueryParameter("size", "Maximum number of values to return. Default is 100, max is 5000.").
-			DataType("int").DefaultValue("100")))
-
-	e.ws.Route(e.ws.GET("/facets/group").To(e.GroupFacets).
-		Doc("Get all distinct group values with event counts").
-		Writes(gcbapi.KeywordFacetsResponse{}).
-		Param(e.ws.QueryParameter("size", "Maximum number of values to return. Default is 100, max is 5000.").
-			DataType("int").DefaultValue("100")))
-
-	e.ws.Route(e.ws.GET("/facets/location").To(e.LocationFacets).
-		Doc("Get all distinct location values with event counts").
-		Writes(gcbapi.KeywordFacetsResponse{}).
-		Param(e.ws.QueryParameter("size", "Maximum number of values to return. Default is 100, max is 5000.").
-			DataType("int").DefaultValue("100")))
-
-	e.ws.Route(e.ws.GET("/facets/roomName").To(e.RoomNameFacets).
-		Doc("Get all distinct room name values with event counts").
-		Writes(gcbapi.KeywordFacetsResponse{}).
+		Param(e.ws.PathParameter("field", "The field to facet on. Supported fields: gameSystem, group, location, roomName.").
+			DataType("string")).
 		Param(e.ws.QueryParameter("size", "Maximum number of values to return. Default is 100, max is 5000.").
 			DataType("int").DefaultValue("100")))
 
@@ -205,51 +189,26 @@ func (e *EventHandler) Search(req *restful.Request, resp *restful.Response) {
 	resp.WriteHeader(http.StatusOK)
 }
 
-// GroupFacets handles GET /api/events/facets/group
-func (e *EventHandler) GroupFacets(req *restful.Request, resp *restful.Response) {
-	const maxSize = 5000
-	size := 100
-
-	if sizeParam := req.QueryParameter("size"); sizeParam != "" {
-		parsed, err := strconv.Atoi(sizeParam)
-		if err != nil || parsed < 1 {
-			resp.WriteHeader(http.StatusBadRequest)
-			resp.Write([]byte(`{"error":"size must be a positive integer"}`))
-			return
-		}
-		if parsed > maxSize {
-			resp.WriteHeader(http.StatusBadRequest)
-			resp.Write([]byte(`{"error":"size cannot exceed 5000"}`))
-			return
-		}
-		size = parsed
-	}
-
-	facets, err := e.manager.GetKeywordFacets(req.Request.Context(), "group.keyword", size)
-	if err != nil {
-		e.logger.Err(err).Msg("failed to get group facets")
-		body, _ := json.Marshal(gcbapi.KeywordFacetsResponse{Error: "failed to retrieve group facets"})
-		resp.WriteHeader(http.StatusInternalServerError)
-		resp.Write(body)
-		return
-	}
-
-	body, err := json.Marshal(gcbapi.KeywordFacetsResponse{Values: facets})
-	if err != nil {
-		e.logger.Err(err).Msg("failed to marshal group facets response")
-		resp.WriteHeader(http.StatusInternalServerError)
-		resp.Write([]byte(`{"error":"failed to write response"}`))
-		return
-	}
-
-	resp.WriteHeader(http.StatusOK)
-	resp.Write(body)
+// facetFields maps supported facet field names to their OpenSearch keyword subfield.
+var facetFields = map[string]string{
+	"gameSystem": "gameSystem.keyword",
+	"group":      "group.keyword",
+	"location":   "location.keyword",
+	"roomName":   "roomName.keyword",
 }
 
-// LocationFacets handles GET /api/events/facets/location
-func (e *EventHandler) LocationFacets(req *restful.Request, resp *restful.Response) {
+// Facets handles GET /api/events/facets/{field}
+func (e *EventHandler) Facets(req *restful.Request, resp *restful.Response) {
 	const maxSize = 5000
 	size := 100
+
+	fieldParam := req.PathParameter("field")
+	osField, ok := facetFields[fieldParam]
+	if !ok {
+		resp.WriteHeader(http.StatusNotFound)
+		resp.Write([]byte(`{"error":"unsupported facet field"}`))
+		return
+	}
 
 	if sizeParam := req.QueryParameter("size"); sizeParam != "" {
 		parsed, err := strconv.Atoi(sizeParam)
@@ -266,10 +225,10 @@ func (e *EventHandler) LocationFacets(req *restful.Request, resp *restful.Respon
 		size = parsed
 	}
 
-	facets, err := e.manager.GetKeywordFacets(req.Request.Context(), "location.keyword", size)
+	facets, err := e.manager.GetKeywordFacets(req.Request.Context(), osField, size)
 	if err != nil {
-		e.logger.Err(err).Msg("failed to get location facets")
-		body, _ := json.Marshal(gcbapi.KeywordFacetsResponse{Error: "failed to retrieve location facets"})
+		e.logger.Err(err).Msgf("failed to get %s facets", fieldParam)
+		body, _ := json.Marshal(gcbapi.KeywordFacetsResponse{Error: fmt.Sprintf("failed to retrieve %s facets", fieldParam)})
 		resp.WriteHeader(http.StatusInternalServerError)
 		resp.Write(body)
 		return
@@ -277,89 +236,7 @@ func (e *EventHandler) LocationFacets(req *restful.Request, resp *restful.Respon
 
 	body, err := json.Marshal(gcbapi.KeywordFacetsResponse{Values: facets})
 	if err != nil {
-		e.logger.Err(err).Msg("failed to marshal location facets response")
-		resp.WriteHeader(http.StatusInternalServerError)
-		resp.Write([]byte(`{"error":"failed to write response"}`))
-		return
-	}
-
-	resp.WriteHeader(http.StatusOK)
-	resp.Write(body)
-}
-
-// RoomNameFacets handles GET /api/events/facets/roomName
-func (e *EventHandler) RoomNameFacets(req *restful.Request, resp *restful.Response) {
-	const maxSize = 5000
-	size := 100
-
-	if sizeParam := req.QueryParameter("size"); sizeParam != "" {
-		parsed, err := strconv.Atoi(sizeParam)
-		if err != nil || parsed < 1 {
-			resp.WriteHeader(http.StatusBadRequest)
-			resp.Write([]byte(`{"error":"size must be a positive integer"}`))
-			return
-		}
-		if parsed > maxSize {
-			resp.WriteHeader(http.StatusBadRequest)
-			resp.Write([]byte(`{"error":"size cannot exceed 5000"}`))
-			return
-		}
-		size = parsed
-	}
-
-	facets, err := e.manager.GetKeywordFacets(req.Request.Context(), "roomName.keyword", size)
-	if err != nil {
-		e.logger.Err(err).Msg("failed to get room name facets")
-		body, _ := json.Marshal(gcbapi.KeywordFacetsResponse{Error: "failed to retrieve room name facets"})
-		resp.WriteHeader(http.StatusInternalServerError)
-		resp.Write(body)
-		return
-	}
-
-	body, err := json.Marshal(gcbapi.KeywordFacetsResponse{Values: facets})
-	if err != nil {
-		e.logger.Err(err).Msg("failed to marshal room name facets response")
-		resp.WriteHeader(http.StatusInternalServerError)
-		resp.Write([]byte(`{"error":"failed to write response"}`))
-		return
-	}
-
-	resp.WriteHeader(http.StatusOK)
-	resp.Write(body)
-}
-
-// GameSystemFacets handles GET /api/events/facets/gameSystem
-func (e *EventHandler) GameSystemFacets(req *restful.Request, resp *restful.Response) {
-	const maxSize = 5000
-	size := 100
-
-	if sizeParam := req.QueryParameter("size"); sizeParam != "" {
-		parsed, err := strconv.Atoi(sizeParam)
-		if err != nil || parsed < 1 {
-			resp.WriteHeader(http.StatusBadRequest)
-			resp.Write([]byte(`{"error":"size must be a positive integer"}`))
-			return
-		}
-		if parsed > maxSize {
-			resp.WriteHeader(http.StatusBadRequest)
-			resp.Write([]byte(`{"error":"size cannot exceed 5000"}`))
-			return
-		}
-		size = parsed
-	}
-
-	facets, err := e.manager.GetKeywordFacets(req.Request.Context(), "gameSystem.keyword", size)
-	if err != nil {
-		e.logger.Err(err).Msg("failed to get game system facets")
-		body, _ := json.Marshal(gcbapi.KeywordFacetsResponse{Error: "failed to retrieve game system facets"})
-		resp.WriteHeader(http.StatusInternalServerError)
-		resp.Write(body)
-		return
-	}
-
-	body, err := json.Marshal(gcbapi.KeywordFacetsResponse{Values: facets})
-	if err != nil {
-		e.logger.Err(err).Msg("failed to marshal game system facets response")
+		e.logger.Err(err).Msgf("failed to marshal %s facets response", fieldParam)
 		resp.WriteHeader(http.StatusInternalServerError)
 		resp.Write([]byte(`{"error":"failed to write response"}`))
 		return

--- a/internal/event/search.go
+++ b/internal/event/search.go
@@ -48,17 +48,17 @@ func NewSearchField(f string, value string) (search.Term, error) {
 	// Keywords that have no special consideration
 	case GameID, MaterialsRequired, LastChangeLogModification:
 		return search.NewKeyword(f, value)
-	// GameSystem, Group, Location, and RoomName are text fields with .keyword subfields; exact match requires the subfield
-	case GameSystem, Group, Location, RoomName:
+	// GameSystem is a text field with a .keyword subfield; exact match requires the subfield
+	case GameSystem:
 		return search.NewKeyword(f+".keyword", value)
 	// integer
 	case Year, MinPlayers, MaxPlayers, RoundNumber,
 		TotalRounds, TicketsAvailable, TotalTickets:
 		return search.NewNumber(f, value)
 	// Generic full text search fields
-	case Title, ShortDescription, LongDescription,
+	case Group, Title, ShortDescription, LongDescription,
 		RulesEdition, MaterialsProvided, MaterialsRequiredDetails, GMNames, Tournament,
-		TableNumber, Prize, RulesComplexity:
+		Location, RoomName, TableNumber, Prize, RulesComplexity:
 		return search.NewText(f, value)
 	// Full text search fields that have a subfield as well
 	case Email, Website:

--- a/internal/event/search.go
+++ b/internal/event/search.go
@@ -48,17 +48,17 @@ func NewSearchField(f string, value string) (search.Term, error) {
 	// Keywords that have no special consideration
 	case GameID, MaterialsRequired, LastChangeLogModification:
 		return search.NewKeyword(f, value)
-	// GameSystem is a text field with a .keyword subfield; exact match requires the subfield
-	case GameSystem:
+	// GameSystem, Group, Location, and RoomName are text fields with .keyword subfields; exact match requires the subfield
+	case GameSystem, Group, Location, RoomName:
 		return search.NewKeyword(f+".keyword", value)
 	// integer
 	case Year, MinPlayers, MaxPlayers, RoundNumber,
 		TotalRounds, TicketsAvailable, TotalTickets:
 		return search.NewNumber(f, value)
 	// Generic full text search fields
-	case Group, Title, ShortDescription, LongDescription,
+	case Title, ShortDescription, LongDescription,
 		RulesEdition, MaterialsProvided, MaterialsRequiredDetails, GMNames, Tournament,
-		Location, RoomName, TableNumber, Prize, RulesComplexity:
+		TableNumber, Prize, RulesComplexity:
 		return search.NewText(f, value)
 	// Full text search fields that have a subfield as well
 	case Email, Website:


### PR DESCRIPTION
## Summary

- Replaces per-field facet endpoints with a single `GET /api/events/facets/{field}` endpoint; unsupported fields return 404
- Adds facet support for: `gameSystem`, `group`, `location`, `roomName`, `ageRequired`, `experienceRequired`, `attendeeRegistration`, `specialCategory`
- Reverts `group`, `location`, and `roomName` search back to full-text `match` (the exact-match switch was premature)

All facets are backed by an OpenSearch `terms` aggregation and share the same response shape.

## Response shape

\`\`\`json
{
  "values": [
    { "value": "Exhibit Hall", "count": 312 },
    { "value": "Marriott Ballroom", "count": 87 }
  ]
}
\`\`\`

## Test plan

- [ ] `GET /api/events/facets/gameSystem` returns 200 with sorted values and counts
- [ ] `GET /api/events/facets/group` returns 200 with sorted values and counts
- [ ] `GET /api/events/facets/location` returns 200 with sorted values and counts
- [ ] `GET /api/events/facets/roomName` returns 200 with sorted values and counts
- [ ] `GET /api/events/facets/ageRequired` returns 200 with sorted values and counts
- [ ] `GET /api/events/facets/experienceRequired` returns 200 with sorted values and counts
- [ ] `GET /api/events/facets/attendeeRegistration` returns 200 with sorted values and counts
- [ ] `GET /api/events/facets/specialCategory` returns 200 with sorted values and counts
- [ ] `GET /api/events/facets/title` returns 404
- [ ] Empty/blank values are excluded from all facet responses
- [ ] `size` parameter is respected and capped at 5000 for all endpoints
- [ ] `?group=...`, `?location=...`, `?roomName=...` still support partial/full-text search

🤖 Generated with [Claude Code](https://claude.com/claude-code)