### PR TITLE
fix: multi-value filtering for ageRequired, experienceRequired, attendeeRegistration, specialCategory

### DIFF
--- a/internal/event/search.go
+++ b/internal/event/search.go
@@ -33,20 +33,40 @@ func NewSearchField(f string, value string) (search.Term, error) {
 	switch field {
 	// keywords that are specific enum types
 	case AgeRequired:
-		return search.NewKeywordSingle(f, string(AgeGroupFromSearchTerm(value)))
+		parts := strings.Split(value, ",")
+		converted := make([]string, len(parts))
+		for i, p := range parts {
+			converted[i] = string(AgeGroupFromSearchTerm(p))
+		}
+		return search.NewKeywordSlice(f, converted)
 	case EventType:
 		parts := strings.Split(value, ",")
 		converted := make([]string, len(parts))
 		for i, p := range parts {
 			converted[i] = string(EventTypeFromSearchTerm(p))
 		}
-		return search.NewKeyword(f, strings.Join(converted, ","))
+		return search.NewKeywordSlice(f, converted)
 	case ExperienceRequired:
-		return search.NewKeywordSingle(f, string(EXPFromSearchTerm(value)))
+		parts := strings.Split(value, ",")
+		converted := make([]string, len(parts))
+		for i, p := range parts {
+			converted[i] = string(EXPFromSearchTerm(p))
+		}
+		return search.NewKeywordSlice(f, converted)
 	case AttendeeRegistration:
-		return search.NewKeywordSingle(f, string(RegistrationFromSearchTerm(value)))
+		parts := strings.Split(value, ",")
+		converted := make([]string, len(parts))
+		for i, p := range parts {
+			converted[i] = string(RegistrationFromSearchTerm(p))
+		}
+		return search.NewKeywordSlice(f, converted)
 	case SpecialCategory:
-		return search.NewKeywordSingle(f, string(CategoryFromSearchTerm(value)))
+		parts := strings.Split(value, ",")
+		converted := make([]string, len(parts))
+		for i, p := range parts {
+			converted[i] = string(CategoryFromSearchTerm(p))
+		}
+		return search.NewKeywordSlice(f, converted)
 	// Keywords that have no special consideration
 	case GameID, MaterialsRequired, LastChangeLogModification:
 		return search.NewKeyword(f, value)

--- a/internal/event/search_test.go
+++ b/internal/event/search_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/gencon_buddy_api/internal/search"
 )
 
 func TestParseSort(t *testing.T) {
@@ -151,6 +153,95 @@ func TestParseSorts(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.Equal(t, tt.wantSorts, got)
+		})
+	}
+}
+
+func TestNewSearchField_MultiValue(t *testing.T) {
+	tests := []struct {
+		name      string
+		field     string
+		value     string
+		wantQuery any
+		wantErr   bool
+	}{
+		{
+			name:      "ageRequired single value",
+			field:     "ageRequired",
+			value:     "kids",
+			wantQuery: map[string]any{"term": map[string]any{"ageRequired": "kids only (12 and under)"}},
+		},
+		{
+			name:  "ageRequired multi value",
+			field: "ageRequired",
+			value: "kids,everyone",
+			wantQuery: map[string]any{
+				"terms": map[string]any{"ageRequired": []string{"kids only (12 and under)", "Everyone (6+)"}},
+			},
+		},
+		{
+			name:      "experienceRequired single value",
+			field:     "experienceRequired",
+			value:     "expert",
+			wantQuery: map[string]any{"term": map[string]any{"experienceRequired": "Expert (You play it regularly and know all the rules)"}},
+		},
+		{
+			name:  "experienceRequired multi value",
+			field: "experienceRequired",
+			value: "none,some",
+			wantQuery: map[string]any{
+				"terms": map[string]any{"experienceRequired": []string{
+					"None (You've never played before - rules will be taught)",
+					"Some (You've played it a bit and understand the basics)",
+				}},
+			},
+		},
+		{
+			name:      "attendeeRegistration single value",
+			field:     "attendeeRegistration",
+			value:     "open",
+			wantQuery: map[string]any{"term": map[string]any{"attendeeRegistration": "Yes, they can register for this round without having played in any other events"}},
+		},
+		{
+			name:  "attendeeRegistration multi value",
+			field: "attendeeRegistration",
+			value: "open,free",
+			wantQuery: map[string]any{
+				"terms": map[string]any{"attendeeRegistration": []string{
+					"Yes, they can register for this round without having played in any other events",
+					"No, this event does not require tickets!",
+				}},
+			},
+		},
+		{
+			name:      "specialCategory single value",
+			field:     "specialCategory",
+			value:     "official",
+			wantQuery: map[string]any{"term": map[string]any{"specialCategory": "Gen Con presents"}},
+		},
+		{
+			name:  "specialCategory multi value",
+			field: "specialCategory",
+			value: "official,premier",
+			wantQuery: map[string]any{
+				"terms": map[string]any{"specialCategory": []string{"Gen Con presents", "Premier Event"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			term, err := NewSearchField(tt.field, tt.value)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			kw, ok := term.(search.Keyword)
+			require.True(t, ok, "expected search.Keyword term")
+			query, err := kw.ToQuery()
+			require.NoError(t, err)
+			require.Equal(t, tt.wantQuery, query)
 		})
 	}
 }

--- a/internal/search/term_keyword.go
+++ b/internal/search/term_keyword.go
@@ -42,6 +42,24 @@ func NewKeyword(field, vals string) (Keyword, error) {
 	return keyword, nil
 }
 
+// NewKeywordSlice creates a terms query from a pre-split slice of values.
+// Use this instead of NewKeyword when values may themselves contain commas.
+func NewKeywordSlice(field string, vals []string) (Keyword, error) {
+	keyword := Keyword{}
+	if field == "" {
+		return keyword, fmt.Errorf("cannot create a keyword term without a field")
+	}
+
+	if len(vals) == 0 {
+		return keyword, fmt.Errorf("cannot create a keyword term on %s without fields", field)
+	}
+
+	keyword.field = field
+	keyword.values = vals
+
+	return keyword, nil
+}
+
 func (k Keyword) ToQuery() (any, error) {
 	if k.field == "" {
 		return nil, fmt.Errorf("cannot create a keyword query without a field")


### PR DESCRIPTION
Closes #49

## Summary

- **Bug**: Multi-value selection for `ageRequired`, `experienceRequired`, `attendeeRegistration`, and `specialCategory` returned 0 results. `NewSearchField` called `NewKeywordSingle` for all four fields, so a comma-joined value like `"none,some"` was passed as a single literal string to OpenSearch instead of two values for a `terms` query.
- **New primitive**: Added `search.NewKeywordSlice(field string, vals []string)` — takes a pre-split slice rather than a comma-delimited string. Required because the stored values for `ExperienceRequired` and `AttendeeRegistration` contain commas themselves (e.g. `"None (You've never played before - rules will be taught)"`), making the existing join-then-split approach in `NewKeyword` destructive.
- **Fix**: Updated `NewSearchField` cases for all four fields (and `EventType` for consistency) to split the incoming short-key CSV, convert each value through its `FromSearchTerm` function, and pass the resulting slice to `NewKeywordSlice`.

## Test plan

- [ ] `go test ./...` passes
- [ ] `golangci-lint run ./...` is clean
- [ ] Search with a single `experienceRequired=expert` — returns matching events
- [ ] Search with `experienceRequired=none,some` — returns events with either value, excludes `expert`
- [ ] Same multi-value check for `ageRequired`, `attendeeRegistration`, `specialCategory`

🤖 Generated with [Claude Code](https://claude.com/claude-code)